### PR TITLE
Return reporters from Runner

### DIFF
--- a/lib/pelusa/cli.rb
+++ b/lib/pelusa/cli.rb
@@ -14,7 +14,16 @@ module Pelusa
         _files = Dir["**/*.rb"]
       end
 
-      Pelusa.run(_files)
+      reporters = Pelusa.run(_files)
+
+      reporters.first.class.print_banner unless reporters.empty?
+
+      exit_code = 0
+      reporters.each do |reporter|
+        reporter.report
+        exit_code = 1 unless reporter.successful?
+      end
+      exit_code
     end
 
     def files

--- a/lib/pelusa/runner.rb
+++ b/lib/pelusa/runner.rb
@@ -14,18 +14,9 @@ module Pelusa
     #
     # Returns an Array of Reports of those file runs.
     def run(files)
-      reporters = Array(files).map do |file|
+      Array(files).map do |file|
         run_file(file)
       end
-      @reporter.print_banner
-
-      exit_code = 0
-
-      reporters.each do |reporter|
-        reporter.report
-        exit_code = 1 unless reporter.successful?
-      end
-      exit_code
     end
 
     # Public: Runs the analyzer on a single file.

--- a/test/pelusa/cli_test.rb
+++ b/test/pelusa/cli_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module Pelusa
+  describe Cli do
+    describe "#run" do
+      before do
+        @report = stub(empty?: false, report: true, class: Reporter)
+        Pelusa.stubs(:run).returns [@report]
+      end
+      describe 'when the reports are successful' do
+        it 'returns 0' do
+          @report.stubs(successful?: true)
+          Cli.new.run().must_equal 0
+        end
+      end
+      describe 'when the reports have failed' do
+        it 'returns 1' do
+          @report.stubs(successful?: false)
+          Cli.new.run().must_equal 1
+        end
+      end
+    end
+  end
+end

--- a/test/pelusa/runner_test.rb
+++ b/test/pelusa/runner_test.rb
@@ -9,18 +9,12 @@ module Pelusa
         Analyzer.stubs(:new).returns analyzer
       end
 
-      describe 'when the reports are successful' do
-        it 'returns 0' do
-          @report.stubs(successful?: true)
-          Pelusa.run(__FILE__).must_equal 0
-        end
+      it 'runs a single file' do
+        Pelusa.run(__FILE__).must_equal [@report]
       end
 
-      describe 'when the reports have failed' do
-        it 'returns 1' do
-          @report.stubs(successful?: false)
-          Pelusa.run(__FILE__).must_equal 1
-        end
+      it 'runs multiple files' do
+        Pelusa.run([__FILE__, __FILE__]).must_equal [@report, @report]
       end
     end
   end


### PR DESCRIPTION
After the CLI interface was [added](https://github.com/codegram/pelusa/commit/b057b1d058f7ad03ca3578b5035ab7c8a4af031f), the `Runner#run` method returned an exit code instead of the value of each reporter's `report` method. This change prohibits the use of other types of reporters which do not print to stdout. For example, if `RubyReporter` is used there would be no way to access or capture its output after the files have been analyzed because those reporters are not exposed by the `Runner` class itself nor are they returned from the `run` method.

I changed the `Runner#run` method to return the list of reporters. The command-line interface should still work because the `Cli` class assumes the responsibility of running the reporters' reports and also returning the appropriate exit code (which I think is appropriate since the exit code is only useful to the bin command). 

Looking forward to hearing your thoughts on this change. Thanks!
