### PR TITLE
Reserved names for ShortIdentifiers lint

### DIFF
--- a/lib/pelusa/lint/short_identifiers.rb
+++ b/lib/pelusa/lint/short_identifiers.rb
@@ -1,6 +1,8 @@
 module Pelusa
   module Lint
     class ShortIdentifiers
+      RESERVED_NAMES = ['p', 'pp', 'id']
+
       def initialize
         @violations = Set.new
       end
@@ -26,7 +28,7 @@ module Pelusa
         iterator = Iterator.new do |node|
           if node.respond_to?(:name)
             name = node.name.respond_to?(:name) ? node.name.name.to_s : node.name.to_s
-            if name =~ /[a-z]/ && name.length < 3 && !["p", "pp"].include?(name)
+            if name =~ /[a-z]/ && name.length < 3 && !RESERVED_NAMES.include?(name)
               next if name =~ /^[A-Z]/ # Ignore constants
               @violations << [name, node.line]
             end

--- a/test/pelusa/lint/short_identifiers_test.rb
+++ b/test/pelusa/lint/short_identifiers_test.rb
@@ -22,6 +22,21 @@ module Pelusa
           end
         end
 
+        describe 'when the class contains short identifier from reserved list' do
+          it 'returns a SuccessAnalysis' do
+            klass = """
+            class Foo
+              def initialize
+                id = 2
+                pp id
+              end
+            end""".to_ast
+
+            analysis = @lint.check(klass)
+            analysis.successful?.must_equal true
+          end
+        end
+
         describe 'when the class contains a short identifier' do
           it 'returns a FailureAnalysis' do
             klass = """


### PR DESCRIPTION
We can manage reserved names now, ie the `id` name is not short. There are a lot of similar names, too.
